### PR TITLE
Style overhaul

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
 
     <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
     <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet">
+    <link href="https://font.googleapis.com/css?family=Open+Sans" rel="stylesheet">
 
     <link rel="stylesheet" href="src/L.Control.Locate.min.css" />
     <script src="src/L.Control.Locate.min.js" charset="utf-8"></script>
@@ -48,7 +49,7 @@
         <div class="sidebar-content">
             <div class="sidebar-pane" id="menu">
                 <h1 class="sidebar-header">
-                    Trappermapper
+                    TRAPPERMAPPER 
                     <span class="sidebar-close"><i class="fa fa-caret-left"></i></span>
                 </h1>
                 <p>Det här är en karta framtagen av programfunktionärerna på Vässarö.</p>
@@ -71,7 +72,7 @@
 
             <div class="sidebar-pane" id="qr">
                 <h1 class="sidebar-header">
-                    QR-kod
+                    QR-KOD 
                     <span class="sidebar-close"><i class="fa fa-caret-left"></i></span>
                 </h1>
                 <p>Du hittar enklast tillbaka till den här kartan genom att spara länken eller skanna QR-koden med din
@@ -82,18 +83,18 @@
 
             <div class="sidebar-pane" id="filter">
                 <h1 class="sidebar-header">
-                    Kartfilter
+                    KARTFILTER 
                     <span class="sidebar-close"><i class="fa fa-caret-left"></i></span>
                 </h1>
                 <div>
-                    <h2>Kartbakgrunder</h2>
+                    <h2>KARTBAKGRUNDER</h2>
                     <input type="radio" id="osmradio" name="selectBackground" value="OpenStreetMap" checked>
                     <label for="osmradio">OpenStreetMap</label><br>
                     <input type="radio" id="satradio" name="selectBackground" value="Satellit">
                     <label for="satradio">Satellit</label>
                 </div>
                 <div>
-                    <h2>Kartfilter</h2>
+                    <h2>KARTFILTER</h2>
                     <div id="filter-box" style="padding-top: 0px;"></div>
                 </div>
             </div>

--- a/style.css
+++ b/style.css
@@ -15,6 +15,7 @@ body,
   border: none !important;
   background: none !important;
 }
+
 .leaflet-touch .leaflet-bar a {
 	width: 36px;
 	height: 36px;

--- a/style.css
+++ b/style.css
@@ -11,6 +11,10 @@ body,
 	z-index: 0;
 }
 
+.leaflet-control-layers {
+  border: none !important;
+  background: none !important;
+}
 .leaflet-touch .leaflet-bar a {
 	width: 36px;
 	height: 36px;

--- a/style.css
+++ b/style.css
@@ -1,6 +1,18 @@
+:root {
+  --accent-color: #5f8789;
+  --text-color: #666666;
+  --manifold-color: #e1e1e1;
+  --std-font: "Open Sans";
+}
+
 body {
 	margin: 0;
 	padding: 0;
+  font-family: var(--std-font);
+}
+
+p {
+  color: var(--text-color);
 }
 
 html,
@@ -9,6 +21,15 @@ body,
 	height: 100%;
 	width: 100vw;
 	z-index: 0;
+}
+
+.sidebar-tabs > li.active, .sidebar-tabs > ul > li.active {
+  color: #fff;
+  background-color: var(--accent-color); 
+}
+
+.sidebar-header {
+  background-color: var(--accent-color);
 }
 
 .leaflet-control-layers {


### PR DESCRIPTION
This pull request is an extended version of #44. 

## Resolving #39 

The Layer-control is changed by directly changing that class in `style.css`. The chage uses `!important` to override any style declarations made by `leaflet.css`. 

```css
/* ./style.css */
.leaflet-control-layers {
  border: none !important;
  background: none !important;
}
```


## Style overhaul

The colors and fonts of the application have been overhauled to match that of the [Vässarö Webiste](https://vassaro.se/).

Colors and default font are declared as variables in the beginning of `./style.css`:

```css
/* ./style.css */
/* BOF */
:root {
  --accent-color: #5f8789;
  --text-color: #666666;
  --manifold-color: #e1e1e1;
  --std-font: "Open Sans";
}
```

All headings have also been capitalised, in accordance with the [Vässarö Website](https://vassaro.se/).